### PR TITLE
fix interfaces so that benchmarks compile

### DIFF
--- a/examples/benchmark_construct.rs
+++ b/examples/benchmark_construct.rs
@@ -183,13 +183,13 @@ fn benchmark_strawman2(num_packets: usize) -> (Duration, u64) {
     (duration, cycles)
 }
 
-fn benchmark<T: PowerSumQuack + Serialize>(
+fn benchmark<T: PowerSumQuack + Quack + Serialize>(
     mut quack: T,
     name: &str,
     num_packets: usize,
 ) -> (Duration, u64)
 where
-    Standard: Distribution<<T as PowerSumQuack>::Element>,
+    Standard: Distribution<<T as Quack>::Element>,
 {
     let numbers = gen_numbers(num_packets);
 

--- a/examples/benchmark_decode.rs
+++ b/examples/benchmark_decode.rs
@@ -211,7 +211,7 @@ fn benchmark_factor_u32(threshold: usize, num_packets: usize, num_drop: usize) -
     for &number in numbers.iter().take(num_packets) {
         acc1.insert(number);
     }
-    acc1.sub_assign(acc2);
+    acc1.sub_assign(&acc2);
     let dropped = acc1.decode_by_factorization().unwrap();
     let (duration, cycles) = t.stop();
     info!(
@@ -227,7 +227,7 @@ fn benchmark_factor_u32(threshold: usize, num_packets: usize, num_drop: usize) -
     (duration, cycles)
 }
 
-fn benchmark<T: PowerSumQuack>(
+fn benchmark<T: PowerSumQuack + Quack>(
     mut acc1: T,
     mut acc2: T,
     name: &str,
@@ -235,8 +235,8 @@ fn benchmark<T: PowerSumQuack>(
     num_drop: usize,
 ) -> (Duration, u64)
 where
-    Standard: Distribution<<T as PowerSumQuack>::Element>,
-    <T as PowerSumQuack>::Element: Copy,
+    Standard: Distribution<<T as Quack>::Element>,
+    <T as Quack>::Element: Copy,
 {
     let numbers = gen_numbers(num_packets);
 
@@ -249,7 +249,7 @@ where
     for &number in numbers.iter().take(num_packets) {
         acc1.insert(number);
     }
-    acc1.sub_assign(acc2);
+    acc1.sub_assign(&acc2);
     let dropped = acc1.decode_with_log(&numbers);
     let (duration, cycles) = t.stop();
     info!(

--- a/examples/benchmark_riblt.rs
+++ b/examples/benchmark_riblt.rs
@@ -38,7 +38,7 @@ struct Cli {
 #[derive(ValueEnum, Debug, Copy, Clone)]
 enum QuackType {
     PowerSum,
-    IBLT,
+    RIBLT,
 }
 
 trait BenchmarkResult {
@@ -132,7 +132,7 @@ fn benchmark_encode(
     // Setup the benchmark
     let mut q = match quack_ty {
         QuackType::PowerSum => QuackWrapper::new(num_symbols, false),
-        QuackType::IBLT => QuackWrapper::new(num_symbols, true),
+        QuackType::RIBLT => QuackWrapper::new(num_symbols, true),
     };
 
     // Benchmark encoding
@@ -318,7 +318,7 @@ fn main() {
                 benchmark(args.quack_ty, benchmark_psum_decode, num_errors);
             }
         }
-        QuackType::IBLT => {
+        QuackType::RIBLT => {
             if let Some(encode) = args.encode {
                 let num_symbols = if encode.is_empty() {
                     default_inputs.as_slice()

--- a/src/arithmetic/modint.rs
+++ b/src/arithmetic/modint.rs
@@ -12,7 +12,7 @@ pub struct ModularInteger<T> {
 }
 
 /// Arithmetic operations and other properties of the modular integer field.
-pub trait ModularArithmetic {
+pub trait ModularArithmetic: Clone {
     /// The smallest unsigned integer type that fits elements in the field.
     type SmallModulusType;
 
@@ -66,12 +66,12 @@ pub trait ModularArithmetic {
     }
 
     /// Performs the `-` operation in the finite field.
-    fn sub(self, rhs: Self) -> Self
+    fn sub(&self, rhs: &Self) -> Self
     where
         Self: Sized,
     {
-        let mut result = self;
-        result.sub_assign(rhs);
+        let mut result = self.clone();
+        result.sub_assign(rhs.clone());
         result
     }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -96,7 +96,7 @@ pub extern "C" fn quack_coeffs_eval(coeffs: *mut CoefficientVectorU32, x: u32) -
     debug_assert!(!coeffs.is_null());
     let coeffs = unsafe { Box::from_raw(coeffs) };
     let result = eval(&coeffs, x);
-    Box::into_raw(Box::new(coeffs));
+    let _ = Box::into_raw(Box::new(coeffs));
     result.value()
 }
 

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -69,7 +69,7 @@ impl Quack for MontgomeryQuack {
         }
     }
 
-    fn sub_assign(&mut self, rhs: Self) {
+    fn sub_assign(&mut self, rhs: &Self) {
         assert_eq!(
             self.threshold(),
             rhs.threshold(),
@@ -82,8 +82,8 @@ impl Quack for MontgomeryQuack {
         self.last_value = None;
     }
 
-    fn sub(self, rhs: Self) -> Self {
-        let mut result = self;
+    fn sub(&self, rhs: &Self) -> Self {
+        let mut result = self.clone();
         result.sub_assign(rhs);
         result
     }
@@ -120,7 +120,7 @@ impl PowerSumQuack for MontgomeryQuack {
         coeffs[0] = self.power_sums[0].neg();
         for i in 1..coeffs.len() {
             for j in 0..i {
-                coeffs[i] = coeffs[i].sub(self.power_sums[j].mul(coeffs[i - j - 1]));
+                coeffs[i] = coeffs[i].sub(&self.power_sums[j].mul(coeffs[i - j - 1]));
             }
             coeffs[i].sub_assign(self.power_sums[i]);
             coeffs[i].mul_assign(INVERSE_TABLE_MONTGOMERY[i]);

--- a/src/power_sum.rs
+++ b/src/power_sum.rs
@@ -15,7 +15,8 @@ cfg_montgomery! {
 }
 
 /// 32-bit power sum quACK.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// NOTE: Serialize/Deserialize used for benchmarks
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PowerSumQuackU32 {
     power_sums: Vec<ModularInteger<u32>>,
     last_value: Option<ModularInteger<u32>>,
@@ -161,7 +162,7 @@ impl Quack for PowerSumQuackU32 {
         let threshold = std::cmp::min(self.threshold(), rhs.threshold());
         let power_sums = self.power_sums.iter().zip(rhs.power_sums.iter())
             .take(threshold)
-            .map(|(lhs, rhs)| lhs.sub(*rhs))
+            .map(|(lhs, rhs)| lhs.sub(rhs))
             .collect();
         Self {
             power_sums,
@@ -189,7 +190,7 @@ impl PowerSumQuack for PowerSumQuackU32 {
         coeffs[0] = self.power_sums[0].neg();
         for i in 1..coeffs.len() {
             for j in 0..i {
-                coeffs[i] = coeffs[i].sub(self.power_sums[j].mul(coeffs[i - j - 1]));
+                coeffs[i] = coeffs[i].sub(&self.power_sums[j].mul(coeffs[i - j - 1]));
             }
             coeffs[i].sub_assign(self.power_sums[i]);
             coeffs[i].mul_assign(INVERSE_TABLE_U32[i]);
@@ -361,8 +362,8 @@ cfg_montgomery! {
             self.last_value = None;
         }
 
-        fn sub(self, rhs: &Self) -> Self {
-            let mut result = self;
+        fn sub(&self, rhs: &Self) -> Self {
+            let mut result = self.clone();
             result.sub_assign(rhs);
             result
         }
@@ -373,7 +374,7 @@ cfg_montgomery! {
 
         fn decode_with_log(&self, log: &[Self::Element]) -> Vec<Self::Element> {
             if self.count() == 0 {
-                vec![];
+                return Vec::<Self::Element>::new();
             }
             let coeffs = self.to_coeffs();
             log.iter()
@@ -397,7 +398,7 @@ cfg_montgomery! {
             coeffs[0] = self.power_sums[0].neg();
             for i in 1..coeffs.len() {
                 for j in 0..i {
-                    coeffs[i] = coeffs[i].sub(self.power_sums[j].mul(coeffs[i - j - 1]));
+                    coeffs[i] = coeffs[i].sub(&self.power_sums[j].mul(coeffs[i - j - 1]));
                 }
                 coeffs[i].sub_assign(self.power_sums[i]);
                 coeffs[i].mul_assign(INVERSE_TABLE_U64[i]);
@@ -481,8 +482,8 @@ cfg_power_table! {
             self.last_value = None;
         }
 
-        fn sub(self, rhs: &Self) -> Self {
-            let mut result = self;
+        fn sub(&self, rhs: &Self) -> Self {
+            let mut result = self.clone();
             result.sub_assign(rhs);
             result
         }
@@ -519,7 +520,7 @@ cfg_power_table! {
             coeffs[0] = self.power_sums[0].neg();
             for i in 1..coeffs.len() {
                 for j in 0..i {
-                    coeffs[i] = coeffs[i].sub(self.power_sums[j].mul(coeffs[i - j - 1]));
+                    coeffs[i] = coeffs[i].sub(&self.power_sums[j].mul(coeffs[i - j - 1]));
                 }
                 coeffs[i].sub_assign(self.power_sums[i]);
                 coeffs[i].mul_assign(INVERSE_TABLE_U16[i]);

--- a/src/power_sum.rs
+++ b/src/power_sum.rs
@@ -3,7 +3,7 @@ use crate::precompute::INVERSE_TABLE_U32;
 use crate::Quack;
 use std::fmt::Debug;
 
-#[cfg(any(feature = "power_table", feature = "montgomery", doc))]
+// #[cfg(any(feature = "power_table", feature = "montgomery", doc))]
 use serde::{Deserialize, Serialize};
 
 cfg_power_table! {

--- a/src/power_table.rs
+++ b/src/power_table.rs
@@ -69,7 +69,7 @@ impl Quack for PowerTableQuack {
         }
     }
 
-    fn sub_assign(&mut self, rhs: Self) {
+    fn sub_assign(&mut self, rhs: &Self) {
         assert_eq!(
             self.threshold(),
             rhs.threshold(),
@@ -82,8 +82,8 @@ impl Quack for PowerTableQuack {
         self.last_value = None;
     }
 
-    fn sub(self, rhs: Self) -> Self {
-        let mut result = self;
+    fn sub(&self, rhs: &Self) -> Self {
+        let mut result = self.clone();
         result.sub_assign(rhs);
         result
     }
@@ -118,7 +118,7 @@ impl PowerSumQuack for PowerTableQuack {
         coeffs[0] = self.power_sums[0].neg();
         for i in 1..coeffs.len() {
             for j in 0..i {
-                coeffs[i] = coeffs[i].sub(self.power_sums[j].mul(coeffs[i - j - 1]));
+                coeffs[i] = coeffs[i].sub(&self.power_sums[j].mul(coeffs[i - j - 1]));
             }
             coeffs[i].sub_assign(self.power_sums[i]);
             coeffs[i].mul_assign(INVERSE_TABLE_U16[i]);


### PR DESCRIPTION
Not 100% sure about all of these changes. E.g., I'm not familiar with the Montgomery quack and some of the other benchmarks from the original Sidekick paper. 

I think that we changed trait interfaces and implementations this year without changing all of the legacy/benchmark code. 